### PR TITLE
Fix compatibility with puppet-lint 2.2

### DIFF
--- a/lib/puppet-lint/plugins/explicit_hiera_class_param_lookup.rb
+++ b/lib/puppet-lint/plugins/explicit_hiera_class_param_lookup.rb
@@ -3,7 +3,7 @@ PuppetLint.new_check(:explicit_hiera_class_param_lookup) do
     class_indexes.each do |class_idx|
 
       class_idx[:param_tokens].select { |t|
-        t.type == :NAME and t.value == 'hiera'
+        (t.type == :NAME or t.type == :FUNCTION_NAME) and t.value == 'hiera'
       }.each do |token|
 
         next unless token.next_code_token.type == :LPAREN


### PR DESCRIPTION
puppet-lint 2.2 introduced the :FUNCTION_NAME token type, effectively
breaking the existing simple checking for :NAME.  Here we check for
either token, so the plugin will continue to work pre 2.2.